### PR TITLE
49 implement images in the latest news section in home page

### DIFF
--- a/src/components/index/latest-news.jsx
+++ b/src/components/index/latest-news.jsx
@@ -3,6 +3,7 @@ import Tooltip from 'react-bootstrap/Tooltip';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Link from 'next/link';
+import OptionalImage from '../optional-image';
 import moment from 'moment';
 
 moment.locale('es');
@@ -27,13 +28,11 @@ const Content = ({ content }) => (
   <>
     <Link {...content.Routing}>
       <a className="text-primary text-decoration-none">
-        <svg className="rounded img-fluid" xmlns="http://www.w3.org/2000/svg">
-          <rect width="100%" height="100%" fill="#868e96" />
-        </svg>
         <h3>{content.Title}</h3>
+        <ContentUpdateTime content={content} />
+        <OptionalImage image={content.Thumbnail} fluid rounded className="mb-1" />
       </a>
     </Link>
-    <ContentUpdateTime content={content} />
     <p>{content.Summary}</p>
   </>
 );
@@ -41,7 +40,7 @@ const Content = ({ content }) => (
 const LatestNews = ({ featuredContent }) => (
   <section name="latest-news">
     <h2>Últimas noticias</h2>
-    <Row lg={4} md={2} sm={1}>
+    <Row lg={3} md={2} sm={1}>
       {featuredContent.map((content) => (
         <Col key={content.id}>
           <Content content={content} />


### PR DESCRIPTION
See https://trello.com/c/9HLcRXcB/49-implement-images-in-the-latest-news-section-in-home-page

Requires https://github.com/ahoraquesinosven/ui-website/pull/10 merged first.

Adds an `OptionalImage` component to the latest news section in the index page.