### PR TITLE
Implements support for embeded elements in markdown content

### DIFF
--- a/src/components/markdown-renderer.jsx
+++ b/src/components/markdown-renderer.jsx
@@ -2,11 +2,22 @@ import Markdown from 'react-markdown';
 import Image from 'react-bootstrap/Image';
 
 const customRenderers = {
-  image: (props) => <Image {...props} fluid rounded className="content-image" />,
+  image: (props) => (
+    <Image {...props} fluid rounded className="content-image" />
+  ),
+  html: ({ value }) => (
+    <div
+      className="embed-responsive embed-responsive-16by9"
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{
+        __html: value,
+      }}
+    />
+  ),
 };
 
 const CustomMarkdownRenderer = (props) => (
-  <Markdown {...props} renderers={customRenderers} />
+  <Markdown {...props} escapeHtml={false} renderers={customRenderers} />
 );
 
 export default CustomMarkdownRenderer;

--- a/src/pages/_document.jsx
+++ b/src/pages/_document.jsx
@@ -16,6 +16,7 @@ class MyDocument extends Document {
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Ubuntu" />
           <script async src="https://www.googletagmanager.com/gtag/js?id=UA-171618131-1" />
           <script
+            // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
               __html: `
                     window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
See https://trello.com/c/IltccRj1/106-display-videos-from-youtube-when-it-is-on-the-description

This sets the markdown renderer so that embeded tags in any content is surrounded by an `embeded-responsive` tag, from bootstrap, which makes the embeded document responsive.

I also fixed some preexisting eslint warnings when using `dangerouslySetInnerHtml`.

Some screenshots using some sample youtube content:

![embeded-responsive-tablet](https://user-images.githubusercontent.com/1887812/86521442-362ad480-be27-11ea-8234-00a7881e282b.png)

![embeded-responsive-laptop](https://user-images.githubusercontent.com/1887812/86521439-2e6b3000-be27-11ea-829c-5e70a5b99275.png)
:
![embeded-responsive-iphone](https://user-images.githubusercontent.com/1887812/86521436-2ca16c80-be27-11ea-9570-1d0b5ae29b25.png)
