### PR TITLE
Hotfix/16 falta el texto en el detalle de informe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.4.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "bootstrap": "^4.6.2",
+        "hast-util-to-html": "^8.0.4",
         "moment": "^2.29.4",
         "next": "^13.4.10",
         "node-fetch": "^3.3.1",
@@ -21,6 +22,7 @@
         "react-bootstrap": "^1.6.7",
         "react-dom": "^18.2.0",
         "react-markdown": "^8.0.7",
+        "rehype-raw": "^6.1.1",
         "sass": "^1.63.6"
       },
       "devDependencies": {
@@ -352,6 +354,11 @@
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
+    },
+    "node_modules/@types/parse5": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
+      "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.3",
@@ -763,6 +770,15 @@
         }
       ]
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -781,6 +797,24 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -1926,6 +1960,97 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hast-util-from-parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-7.1.2.tgz",
+      "integrity": "sha512-Nz7FfPBuljzsN3tCQ4kCBKqdNhQE2l0Tn+X1ubgKBPRoiDIu1mL08Cfw4k7q71+Duyaw7DXDN+VTAp4Vh3oCOw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0",
+        "hastscript": "^7.0.0",
+        "property-information": "^6.0.0",
+        "vfile": "^5.0.0",
+        "vfile-location": "^4.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
+      "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
+      "dependencies": {
+        "@types/hast": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-7.2.3.tgz",
+      "integrity": "sha512-RujVQfVsOrxzPOPSzZFiwofMArbQke6DJjnFfceiEbFh7S05CbPt0cYN+A5YeD3pso0JQk6O1aHBnx9+Pm2uqg==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/parse5": "^6.0.0",
+        "hast-util-from-parse5": "^7.0.0",
+        "hast-util-to-parse5": "^7.0.0",
+        "html-void-elements": "^2.0.0",
+        "parse5": "^6.0.0",
+        "unist-util-position": "^4.0.0",
+        "unist-util-visit": "^4.0.0",
+        "vfile": "^5.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-8.0.4.tgz",
+      "integrity": "sha512-4tpQTUOr9BMjtYyNlt0P50mH7xj0Ks2xpo8M943Vykljf99HW6EzulIoJP1N3eKOSScEHzyzi9dm7/cn0RfGwA==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-raw": "^7.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "html-void-elements": "^2.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-7.1.0.tgz",
+      "integrity": "sha512-YNRgAJkH2Jky5ySkIqFXTQiaqcAtJyVE+D5lkN6CdtOqrnkLfGYYrEcKuHOJZlp+MwjSwuD3fZuawI+sic/RBw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
@@ -1933,6 +2058,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
+      "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^3.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-2.0.1.tgz",
+      "integrity": "sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/iconv-lite": {
@@ -3383,6 +3533,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3690,6 +3845,20 @@
       "dev": true,
       "engines": {
         "node": ">=6.5.0"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-6.1.1.tgz",
+      "integrity": "sha512-d6AKtisSRtDRX4aSPsJGTfnzrX2ZkHQLE5kiUuGOeEoLpbEulFF4hj0mLPbsa+7vmguDKOVVEQdHKDSwoaIDsQ==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "hast-util-raw": "^7.2.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-parse": {
@@ -4073,6 +4242,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.3.tgz",
+      "integrity": "sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -4529,6 +4711,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-location": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-4.1.0.tgz",
+      "integrity": "sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vfile-message": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
@@ -4560,6 +4755,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/web-streams-polyfill": {
@@ -4650,6 +4854,15 @@
       "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   },
@@ -4857,6 +5070,11 @@
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
+    },
+    "@types/parse5": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
+      "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g=="
     },
     "@types/prop-types": {
       "version": "15.7.3",
@@ -5156,6 +5374,11 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001435.tgz",
       "integrity": "sha512-kdCkUTjR+v4YAJelyiDTqiu82BDr4W4CP5sgTA0ZBmqn30XfS2ZghPLMowik9TPhS+psWJiUNxsqLyurDbmutA=="
     },
+    "ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -5171,6 +5394,16 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="
+    },
+    "character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="
+    },
+    "character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
     },
     "chardet": {
       "version": "0.7.0",
@@ -6036,10 +6269,98 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "hast-util-from-parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-7.1.2.tgz",
+      "integrity": "sha512-Nz7FfPBuljzsN3tCQ4kCBKqdNhQE2l0Tn+X1ubgKBPRoiDIu1mL08Cfw4k7q71+Duyaw7DXDN+VTAp4Vh3oCOw==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0",
+        "hastscript": "^7.0.0",
+        "property-information": "^6.0.0",
+        "vfile": "^5.0.0",
+        "vfile-location": "^4.0.0",
+        "web-namespaces": "^2.0.0"
+      }
+    },
+    "hast-util-parse-selector": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
+      "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
+      "requires": {
+        "@types/hast": "^2.0.0"
+      }
+    },
+    "hast-util-raw": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-7.2.3.tgz",
+      "integrity": "sha512-RujVQfVsOrxzPOPSzZFiwofMArbQke6DJjnFfceiEbFh7S05CbPt0cYN+A5YeD3pso0JQk6O1aHBnx9+Pm2uqg==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/parse5": "^6.0.0",
+        "hast-util-from-parse5": "^7.0.0",
+        "hast-util-to-parse5": "^7.0.0",
+        "html-void-elements": "^2.0.0",
+        "parse5": "^6.0.0",
+        "unist-util-position": "^4.0.0",
+        "unist-util-visit": "^4.0.0",
+        "vfile": "^5.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      }
+    },
+    "hast-util-to-html": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-8.0.4.tgz",
+      "integrity": "sha512-4tpQTUOr9BMjtYyNlt0P50mH7xj0Ks2xpo8M943Vykljf99HW6EzulIoJP1N3eKOSScEHzyzi9dm7/cn0RfGwA==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-raw": "^7.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "html-void-elements": "^2.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      }
+    },
+    "hast-util-to-parse5": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-7.1.0.tgz",
+      "integrity": "sha512-YNRgAJkH2Jky5ySkIqFXTQiaqcAtJyVE+D5lkN6CdtOqrnkLfGYYrEcKuHOJZlp+MwjSwuD3fZuawI+sic/RBw==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      }
+    },
     "hast-util-whitespace": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
       "integrity": "sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng=="
+    },
+    "hastscript": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
+      "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^3.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      }
+    },
+    "html-void-elements": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-2.0.1.tgz",
+      "integrity": "sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -6971,6 +7292,11 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -7199,6 +7525,16 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
+    },
+    "rehype-raw": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-6.1.1.tgz",
+      "integrity": "sha512-d6AKtisSRtDRX4aSPsJGTfnzrX2ZkHQLE5kiUuGOeEoLpbEulFF4hj0mLPbsa+7vmguDKOVVEQdHKDSwoaIDsQ==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "hast-util-raw": "^7.2.0",
+        "unified": "^10.0.0"
+      }
     },
     "remark-parse": {
       "version": "10.0.2",
@@ -7486,6 +7822,15 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
+      }
+    },
+    "stringify-entities": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.3.tgz",
+      "integrity": "sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==",
+      "requires": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
       }
     },
     "strip-ansi": {
@@ -7818,6 +8163,15 @@
         "vfile-message": "^3.0.0"
       }
     },
+    "vfile-location": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-4.1.0.tgz",
+      "integrity": "sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "vfile": "^5.0.0"
+      }
+    },
     "vfile-message": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
@@ -7843,6 +8197,11 @@
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       }
+    },
+    "web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="
     },
     "web-streams-polyfill": {
       "version": "3.2.1",
@@ -7909,6 +8268,11 @@
       "version": "3.21.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
       "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw=="
+    },
+    "zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.4.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "bootstrap": "^4.6.2",
+    "hast-util-to-html": "^8.0.4",
     "moment": "^2.29.4",
     "next": "^13.4.10",
     "node-fetch": "^3.3.1",
@@ -31,6 +32,7 @@
     "react-bootstrap": "^1.6.7",
     "react-dom": "^18.2.0",
     "react-markdown": "^8.0.7",
+    "rehype-raw": "^6.1.1",
     "sass": "^1.63.6"
   },
   "devDependencies": {

--- a/src/components/markdown-renderer.jsx
+++ b/src/components/markdown-renderer.jsx
@@ -1,11 +1,11 @@
 import Markdown from 'react-markdown';
 import Image from 'react-bootstrap/Image';
 
-const customRenderers = {
-  image: (props) => (
+const components = {
+  img: (props) => (
     <Image {...props} fluid rounded className="content-image" />
   ),
-  html: ({ value }) => (
+  iframe: ({ value }) => (
     <div
       className="embed-responsive embed-responsive-16by9"
       // eslint-disable-next-line react/no-danger
@@ -16,8 +16,10 @@ const customRenderers = {
   ),
 };
 
-const CustomMarkdownRenderer = (props) => (
-  <Markdown {...props} escapeHtml={false} renderers={customRenderers} />
+const CustomMarkdownRenderer = ({ children, ...props }) => (
+  <Markdown {...props} components={components}>
+    {children}
+  </Markdown>
 );
 
 export default CustomMarkdownRenderer;

--- a/src/components/markdown-renderer.jsx
+++ b/src/components/markdown-renderer.jsx
@@ -1,23 +1,30 @@
 import Markdown from 'react-markdown';
+import rehypeRaw from 'rehype-raw';
+import {toHtml} from 'hast-util-to-html';
 import Image from 'react-bootstrap/Image';
+
+const rehypePlugins = [
+  rehypeRaw,
+];
 
 const components = {
   img: (props) => (
     <Image {...props} fluid rounded className="content-image" />
   ),
-  iframe: ({ value }) => (
-    <div
-      className="embed-responsive embed-responsive-16by9"
-      // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{
-        __html: value,
-      }}
-    />
-  ),
+  iframe: (element) => { 
+    return (
+      <div
+        className="embed-responsive embed-responsive-16by9 mb-3"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{
+          __html: toHtml(element.node),
+        }}
+      />
+    ) },
 };
 
 const CustomMarkdownRenderer = ({ children, ...props }) => (
-  <Markdown {...props} components={components}>
+  <Markdown {...props} components={components} rehypePlugins={rehypePlugins}>
     {children}
   </Markdown>
 );

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -63,7 +63,9 @@ const AboutUs = ({ aboutUs, members, collaborators }) => (
     </div>
     <Container className="mt-2">
       <OptionalImage image={aboutUs.cover} fluid rounded className="mb-3 content-image" />
-      <Markdown source={aboutUs.content} />
+      <Markdown>
+        {aboutUs.content}
+      </Markdown>
       <h2>Equipo</h2>
       <Row lg={3} md={2} sm={1} xs={1}>
         {members.map((member) => (

--- a/src/pages/activities/[slug].jsx
+++ b/src/pages/activities/[slug].jsx
@@ -42,7 +42,9 @@ const Activity = ({ activity }) => (
       </div>
       <OptionalImage image={activity.mainImage} fluid rounded className="mt-3 mb-3 content-image" />
       <ActivityDetails activity={activity} />
-      <Markdown source={activity.content} />
+      <Markdown>
+        {activity.content}
+      </Markdown>
     </Container>
   </>
 );

--- a/src/pages/activities/[slug].jsx
+++ b/src/pages/activities/[slug].jsx
@@ -27,10 +27,7 @@ const ActivityDetails = ({ activity }) => {
 const Activity = ({ activity }) => (
   <>
     <Head>
-      <title>
-        AHORA QUE SI NOS VEN - Actividades -
-        {activity.title}
-      </title>
+      <title>{`AHORA QUE SI NOS VEN - Actividades - ${activity.title}`}</title>
       <meta name="description" content={activity.summary} />
     </Head>
     <Container className="mt-2">

--- a/src/pages/activities/index.jsx
+++ b/src/pages/activities/index.jsx
@@ -16,10 +16,7 @@ const SectionBanner = ({ category }) => (
 const Activities = ({ activities, category }) => (
   <>
     <Head>
-      <title>
-        AHORA QUE SI NOS VEN -
-        {pageTitle(category)}
-      </title>
+      <title>{`AHORA QUE SI NOS VEN - ${pageTitle(category)}`}</title>
       <meta name="description" content="El Observatorio pretende ser un espacio de producción de información, conocimiento y formación puesto al servivio de las grandes mayorias silenciadas de nuestro país. Lo integramos personas que provenimos de distintas experiencias de formación y participación, a su vez que es un espacio abierto a la incorporación de distintos saberes. Asumimos el feminismo popular como identidad desde la cual estructuramos nuestro pensamiento, trabajo y acción. Somos parte del movimiento Marea Feminista Popular y Disidente." />
     </Head>
     <SectionBanner category={category} />

--- a/src/pages/articles/[slug].jsx
+++ b/src/pages/articles/[slug].jsx
@@ -62,7 +62,9 @@ const Article = ({ article }) => (
       </div>
       <OptionalImage image={article.mainImage} fluid rounded className="mt-3 mb-3 content-image" />
       <ArticleDetails article={article} />
-      <Markdown source={article.content} />
+      <Markdown>
+        {article.content}
+      </Markdown>
       <AdditionalImagesCarousel images={article.additionalImages} />
     </Container>
   </>

--- a/src/pages/articles/[slug].jsx
+++ b/src/pages/articles/[slug].jsx
@@ -47,10 +47,7 @@ const ArticleDetails = ({ article }) => {
 const Article = ({ article }) => (
   <>
     <Head>
-      <title>
-        AHORA QUE SI NOS VEN - Artículos -
-        {article.title}
-      </title>
+      <title>{`AHORA QUE SI NOS VEN - Artículos - ${article.title}`}</title>
       <meta name="description" content={article.summary} />
     </Head>
     <Container className="mt-5">

--- a/src/pages/articles/index.jsx
+++ b/src/pages/articles/index.jsx
@@ -24,11 +24,7 @@ const SectionBanner = ({ categories }) => (
 const Articles = ({ articles, categories }) => (
   <>
     <Head>
-      <title>
-        AHORA QUE SI NOS VEN
-        -
-        {pageTitle(categories)}
-      </title>
+      <title>{`AHORA QUE SI NOS VEN - ${pageTitle(categories)}`}</title>
       <meta name="description" content="Desde el Observatorio AQSNV comenzamos a relevar los femicidios en la Argentina a partir del análisis de medios gráficos y digitales de todo el país luego de la gran movilización del 3 de junio del 2015 en la que la sociedad entera exigió Ni Una Menos. De igual manera realizamos monitoreo de leyes e investigaciones relativas a los distintos tipos de violencias que sufrimos las mujeres, trans, travestis, lesbianas y personas no binaries en todos los ámbitos en los que desarrollamos nuestras relaciones interpersonales: hogar, trabajo, espacio públicos, instituciones educativas, etc." />
     </Head>
     <SectionBanner categories={categories} />

--- a/src/pages/campaigns/[slug].jsx
+++ b/src/pages/campaigns/[slug].jsx
@@ -62,7 +62,9 @@ const Campaign = ({ campaign }) => (
       </div>
       <OptionalImage image={campaign.mainImage} fluid rounded className="mt-3 mb-3 content-image" />
       <CampaignDetails campaign={campaign} />
-      <Markdown source={campaign.content} />
+      <Markdown>
+        {campaign.content}
+      </Markdown>
       <AdditionalImagesCarousel images={campaign.additionalImages} />
     </Container>
   </>

--- a/src/pages/campaigns/[slug].jsx
+++ b/src/pages/campaigns/[slug].jsx
@@ -47,10 +47,7 @@ const CampaignDetails = ({ campaign }) => {
 const Campaign = ({ campaign }) => (
   <>
     <Head>
-      <title>
-        AHORA QUE SI NOS VEN - Campañas -
-        {campaign.title}
-      </title>
+      <title>{`AHORA QUE SI NOS VEN - Campañas - ${campaign.title}`}</title>
       <meta name="description" content={campaign.summary} />
     </Head>
     <Container className="mt-2">

--- a/src/pages/media-presence/[slug].jsx
+++ b/src/pages/media-presence/[slug].jsx
@@ -39,7 +39,9 @@ const MediaPresence = ({ mediaPresence }) => (
       </div>
       <OptionalImage image={mediaPresence.mainImage} fluid rounded className="mt-3 mb-3 content-image" />
       <MediaPresenceDetails mediaPresence={mediaPresence} />
-      <Markdown source={mediaPresence.content} />
+      <Markdown>
+        {mediaPresence.content}
+      </Markdown>
     </Container>
   </>
 );

--- a/src/pages/media-presence/[slug].jsx
+++ b/src/pages/media-presence/[slug].jsx
@@ -24,10 +24,7 @@ const MediaPresenceDetails = ({ mediaPresence }) => (
 const MediaPresence = ({ mediaPresence }) => (
   <>
     <Head>
-      <title>
-        AHORA QUE SI NOS VEN - En los medios -
-        {mediaPresence.title}
-      </title>
+      <title>{`AHORA QUE SI NOS VEN - En los medios - ${mediaPresence.title}`}</title>
       <meta name="description" content={mediaPresence.summary} />
     </Head>
     <Container className="mt-2">

--- a/src/pages/reports/[slug].jsx
+++ b/src/pages/reports/[slug].jsx
@@ -49,10 +49,7 @@ const ReportDetails = ({ report }) => {
 const Report = ({ report }) => (
   <>
     <Head>
-      <title>
-        AHORA QUE SI NOS VEN - Informes -
-        {report.title}
-      </title>
+      <title>{`AHORA QUE SI NOS VEN - Informes - ${report.title}`}</title>
       <meta name="description" content={report.summary} />
     </Head>
     <Container className="mt-5">

--- a/src/pages/reports/[slug].jsx
+++ b/src/pages/reports/[slug].jsx
@@ -64,7 +64,9 @@ const Report = ({ report }) => (
       </div>
       <OptionalImage image={report.mainImage} fluid rounded className="mt-3 mb-3 content-image" />
       <ReportDetails report={report} />
-      <Markdown source={report.content} />
+      <Markdown>
+        {report.content}
+      </Markdown>
       <AdditionalImagesCarousel images={report.additionalImages} />
     </Container>
   </>

--- a/src/pages/reports/index.jsx
+++ b/src/pages/reports/index.jsx
@@ -24,11 +24,7 @@ const SectionBanner = ({ categories }) => (
 const Reports = ({ reports, categories }) => (
   <>
     <Head>
-      <title>
-        AHORA QUE SI NOS VEN
-        -
-        {pageTitle(categories)}
-      </title>
+      <title>{`AHORA QUE SI NOS VEN - ${pageTitle(categories)}`}</title>
       <meta name="description" content="Desde el Observatorio AQSNV comenzamos a relevar los femicidios en la Argentina a partir del análisis de medios gráficos y digitales de todo el país luego de la gran movilización del 3 de junio del 2015 en la que la sociedad entera exigió Ni Una Menos. De igual manera realizamos monitoreo de leyes e investigaciones relativas a los distintos tipos de violencias que sufrimos las mujeres, trans, travestis, lesbianas y personas no binaries en todos los ámbitos en los que desarrollamos nuestras relaciones interpersonales: hogar, trabajo, espacio públicos, instituciones educativas, etc." />
     </Head>
     <SectionBanner categories={categories} />


### PR DESCRIPTION
Related to https://trello.com/c/MQ2jHfjk/16-falta-el-texto-en-el-detalle-de-informe

Summary of changes:

1. Applies changes suggested by migration guide related to https://github.com/remarkjs/react-markdown/blob/main/changelog.md#change-renderers-to-components, https://github.com/remarkjs/react-markdown/blob/main/changelog.md#remove-buggy-html-in-markdown-parser and https://github.com/remarkjs/react-markdown/blob/main/changelog.md#change-source-to-children
2. Fixing embedded content (like youtube videos) on markdown requires a bit of back and forth. See https://github.com/remarkjs/react-markdown#architecture for more context, but basically we require `https://github.com/rehypejs/rehype-raw` as a plugin to allow embedded html content inside markdown, and then we need to convert the [hast](https://github.com/syntax-tree/hast) node that we are receiving out of rehype into raw html, so that we can wrap that with the embedded classes we need for style
3. Added an `mb-3` class to the embed for better spacing on content that doesn't have any text after the embed (was overlapping with footer on those cases).
4. Fixes a warning we were receiving on titles. See https://github.com/vercel/next.js/discussions/38256#discussioncomment-3070196 for more details.